### PR TITLE
Add AM/PM time format option to the extension.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -59,6 +59,7 @@ const Azan = new Lang.Class({
     this._opt_latitude = null;
     this._opt_longitude = null;
     this._opt_timezone = null;
+    this._opt_timeformat12 = false;
 
     this._settings = Convenience.getSettings();
     this._bindSettings();
@@ -232,6 +233,7 @@ const Azan = new Lang.Class({
     this._updateAutoLocation();
     this._opt_latitude = this._settings.get_double(PrefsKeys.LATITUDE);
     this._opt_longitude = this._settings.get_double(PrefsKeys.LONGITUDE);
+    this._opt_timeformat12 = this._settings.get_boolean(PrefsKeys.TIME_FORAMT_12);
     this._opt_timezone = this._settings.get_double(PrefsKeys.TIMEZONE);
   },
   _bindSettings: function() {
@@ -254,6 +256,10 @@ const Azan = new Lang.Class({
     this._settings.connect('changed::' + PrefsKeys.LONGITUDE, Lang.bind(this, function(settings, key) {
         this._opt_longitude = settings.get_double(key);
 
+        this._updateLabel();
+    }));
+    this._settings.connect('changed::' + PrefsKeys.TIME_FORAMT_12, Lang.bind(this, function(settings, key) {
+        this._opt_timeformat12 = settings.get_boolean(key);
         this._updateLabel();
     }));
     this._settings.connect('changed::' + PrefsKeys.TIMEZONE, Lang.bind(this, function(settings, key) {
@@ -289,7 +295,14 @@ const Azan = new Lang.Class({
 
       let currentSeconds = this._calculateSecondsFromDate(currentDate);
 
-      let timesStr = this._prayTimes.getTimes(currentDate, myLocation, myTimezone, 'auto', '24h');
+      let timesStr;
+
+      if (this._opt_timeformat12) {
+        timesStr = this._prayTimes.getTimes(currentDate, myLocation, myTimezone, 'auto', '12h');
+      } else {
+        timesStr = this._prayTimes.getTimes(currentDate, myLocation, myTimezone, 'auto', '24h');
+      }
+
       let timesFloat = this._prayTimes.getTimes(currentDate, myLocation, myTimezone, 'auto', 'Float');
 
       let nearestPrayerId;

--- a/src/org.gnome.shell.extensions.azan.gschema.xml
+++ b/src/org.gnome.shell.extensions.azan.gschema.xml
@@ -26,6 +26,12 @@
         <description>Longitude of your location</description>
     </key>
 
+    <key type="b" name="time-format-12">
+        <default>false</default>
+        <summary>AM/PM time format</summary>
+        <description>Set time format to AM/PM hours</description>
+    </key>
+
     <key type="s" name="timezone">
         <default>"auto"</default>
         <summary>Timezone</summary>

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -254,6 +254,8 @@ const AzanPrefsWidget = new GObject.Class({
 
         this.auto_location = location_page.add_boolean('Automatic location', PrefsKeys.AUTO_LOCATION, updateLocationState);
 
+        this.time_format_12 = location_page.add_boolean('AM/PM time format', PrefsKeys.TIME_FORAMT_12);
+
         this.auto_location.connect('state-set', updateLocationState);
 
         location_page.add_combo('Timezone', PrefsKeys.TIMEZONE, [

--- a/src/prefs_keys.js
+++ b/src/prefs_keys.js
@@ -3,3 +3,4 @@ const CALCULATION_METHOD = 'calculation-method';
 const LATITUDE = 'latitude';
 const LONGITUDE = 'longitude';
 const TIMEZONE = 'timezone';
+const TIME_FORAMT_12 = 'time-format-12';

--- a/src/schemas/org.gnome.shell.extensions.azan.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.azan.gschema.xml
@@ -26,6 +26,12 @@
         <description>Longitude of your location</description>
     </key>
 
+    <key type="b" name="time-format-12">
+        <default>false</default>
+        <summary>AM/PM time format</summary>
+        <description>Set time format to AM/PM hours</description>
+    </key>
+
     <key type="s" name="timezone">
         <default>"auto"</default>
         <summary>Timezone</summary>


### PR DESCRIPTION
Add AM/PM time format option to the extension.
I tested on GNOME Shell 3.30.1 on Ubuntu 18.10 and it works so fine.